### PR TITLE
Hashed json name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ const xlsx2csv    = require( './lib/gulp-wxlsx2csv' )
 const marked      = require( 'gulp-marked' )
 const replace     = require( 'gulp-replace' )
 const rename      = require( 'gulp-rename' )
+const rimraf      = require( 'rimraf' )
 
 gulp.task( 'md', () => {
   gulp.src( 'README.md' )
@@ -42,7 +43,11 @@ gulp.task( 'js', [ 'md' ], function ( cb ) {
   .on( 'end', cb )
 } )
 
-gulp.task( 'data', () => {
+gulp.task( 'clean', cb => {
+  rimraf( './json', cb )
+} )
+
+gulp.task( 'data', [ 'clean' ], () => {
 
   // merge streams of csv and xlsx
   streamqueue(
@@ -78,4 +83,10 @@ gulp.task( 'sass', () => {
     .pipe( gulp.dest( './css' ) )
 } )
 
-gulp.task( 'build', [ 'js', 'data','twitter_bootstrap', 'sass', 'fonts' ] )
+gulp.task( 'build', [
+  'js',
+  'data',
+  'twitter_bootstrap',
+  'sass',
+  'fonts'
+] )

--- a/lib/gulp-wcsv2json.js
+++ b/lib/gulp-wcsv2json.js
@@ -134,6 +134,8 @@ module.exports = function( opts ) {
 
     // container for index:hash map
     const theHash = {}
+    // time seed of hash
+    const time = Date.now().toString()
 
     // integrate menu data
     const menus = data.sources
@@ -147,7 +149,7 @@ module.exports = function( opts ) {
 
     // map array of menu into object with incremental id
     const mappedMenu = menus.reduce( ( result, menu, index ) => {
-      const key = ( menu + Date.now() ).toString()
+      const key = ( menu + time )
       const hash = getMd5sum( key )
       // keep index:hash map
       theHash[index] = hash

--- a/lib/gulp-wcsv2json.js
+++ b/lib/gulp-wcsv2json.js
@@ -7,6 +7,14 @@
 
 const through = require( 'through2' )
 const parse   = require( 'csv-parse' )
+const crypto  = require( 'crypto' )
+
+/**
+ * [getMd5sum description]
+ * @param  {string} key hash seed
+ * @return {string}     hash value
+ */
+const getMd5sum = key => crypto.createHash( 'md5' ).update( key, 'utf8' ).digest( 'hex' )
 
 /**
  * DEFAULT OPTION VALUES
@@ -124,6 +132,9 @@ module.exports = function( opts ) {
    */
   function flush( callback ) {
 
+    // container for index:hash map
+    const theHash = {}
+
     // integrate menu data
     const menus = data.sources
       // array of array of menu
@@ -136,7 +147,11 @@ module.exports = function( opts ) {
 
     // map array of menu into object with incremental id
     const mappedMenu = menus.reduce( ( result, menu, index ) => {
-      result.push( { id: index, value: menu } )
+      const key = menu + index + Date().toString()
+      const hash = getMd5sum( key )
+      // keep index:hash map
+      theHash[index] = hash
+      result.push( { id: hash, value: menu } )
       return result
     }, [] )
 
@@ -160,7 +175,7 @@ module.exports = function( opts ) {
     Object.keys( result ).forEach( key => {
       const itemFile = data.origin.clone()
       itemFile.contents = new Buffer( JSON.stringify( result[key] ) )
-      itemFile.path = `${itemFile.base}/${menus.indexOf( key )}.${OPTS.extension}`
+      itemFile.path = `${itemFile.base}/${theHash[menus.indexOf( key )]}.${OPTS.extension}`
       this.push( itemFile )
     } )
 

--- a/lib/gulp-wcsv2json.js
+++ b/lib/gulp-wcsv2json.js
@@ -147,7 +147,7 @@ module.exports = function( opts ) {
 
     // map array of menu into object with incremental id
     const mappedMenu = menus.reduce( ( result, menu, index ) => {
-      const key = menu + index + Date().toString()
+      const key = ( menu + Date.now() ).toString()
       const hash = getMd5sum( key )
       // keep index:hash map
       theHash[index] = hash

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-riot": "^2.0.0",
     "mocha": "^3.2.0",
+    "rimraf": "^2.6.1",
     "riotify": "^2.0.0",
     "stream-array": "^1.1.2",
     "stream-assert": "^2.0.3",

--- a/tags/menu-item.tag
+++ b/tags/menu-item.tag
@@ -8,7 +8,7 @@
     this.items = opts.json
     this.click = function( e ) {
       const id = e.target.getAttribute( 'data-item' )
-      if ( id.match( /^[0-9]+$/ ) ) {
+      if ( id.match( /^[a-f0-9]+$/ ) ) {
         opts.request
           .get( 'json/' + id + '.json' )
           .set( 'Accept', 'application/json' )

--- a/tests/lib/gulp-wcsv2json.js
+++ b/tests/lib/gulp-wcsv2json.js
@@ -37,7 +37,7 @@ describe( 'gulp-csv2json', () => {
             .pipe( assert.first( file => {
               // match [ { id: 0a1b2c3d4f5.., value: '串本'  } ]
               const json = JSON.parse( file.contents.toString() )
-              expect( json ).to.be.a.Array()
+              expect( json ).to.be.an( 'array' )
               expect( json[0].id ).to.match( HASH )
               expect( json[0].value ).to.be( '串本' )
             } ) )
@@ -101,7 +101,7 @@ describe( 'gulp-csv2json', () => {
             .pipe( assert.first( file => {
               // match [ { id: 0a1b2c.. , value: '串本' }, { id: 0a1b2c.. , value: '白浜' } ]
               const json = JSON.parse( file.contents.toString() )
-              expect( json ).to.be.a.Array()
+              expect( json ).to.be.an( 'array' )
               expect( json[0].id ).to.match( HASH )
               expect( json[0].value ).to.be( '串本' )
               expect( json[1].id ).to.match( HASH )
@@ -184,15 +184,15 @@ describe( 'gulp-csv2json', () => {
         it( 'should return menu array, firstly', done => {
           test( CSV1, CSV2 )
             .pipe( csv2json() )
-            .pipe( assert.first( isJSON( file => {
+            .pipe( assert.first( file => {
               // match [ { id: 0a1b2c.. , value: '串本' }, { id: 0a1b2c.. , value: '白浜' } ]
               const json = JSON.parse( file.contents.toString() )
-              expect( json ).to.be.a.Array()
+              expect( json ).to.be.an( 'array' )
               expect( json[0].id ).to.match( HASH )
               expect( json[0].value ).to.be( '串本' )
               expect( json[1].id ).to.match( HASH )
               expect( json[1].value ).to.be( '白浜' )
-            } ) ) )
+            } ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -303,7 +303,7 @@ describe( 'gulp-csv2json', () => {
           .pipe( assert.first( file => {
             // match [ { id: 0a1b2c.. , value: 'value1' } ]
             const json = JSON.parse( file.contents.toString() )
-            expect( json ).to.be.a.Array()
+            expect( json ).to.be.an( 'array' )
             expect( json[0].id ).to.match( HASH )
             expect( json[0].value ).to.be( 'value1' )
           } ) )
@@ -319,7 +319,13 @@ describe( 'gulp-csv2json', () => {
         test( CSV )
           .pipe( csv2json() )
           .pipe( assert.length( 2 ) )
-          .pipe( assert.first( isJSON( [ { id: 0, value: 'value1' } ] ) ) )
+          .pipe( assert.first( file => {
+            // match [ { id: 0a1b2c.. , value: 'value1' } ]
+            const json = JSON.parse( file.contents.toString() )
+            expect( json ).to.be.an( 'array' )
+            expect( json[0].id ).to.match( HASH )
+            expect( json[0].value ).to.be( 'value1' )
+          } ) )
           .pipe( assert.second( hasName( HASHED_JSON ) ) )
           .pipe( assert.second( isJSON( expected ) ) )
           .pipe( assert.end( done ) )

--- a/tests/lib/gulp-wcsv2json.js
+++ b/tests/lib/gulp-wcsv2json.js
@@ -3,9 +3,13 @@
 const assert      = require( 'stream-assert' )
 const csv2json    = require( '../../lib/gulp-wcsv2json' )
 const test        = require( './helpers/test-csv-stream' )
+const expect      = require( 'expect.js' )
 const expectVinyl = require( './helpers/expect-vinyl' )
 const hasName = expectVinyl.hasName
 const isJSON  = expectVinyl.isJSON
+
+const HASH = /^[a-f0-9]{5,}$/
+const HASHED_JSON = /^[a-f0-9]{5,}\.json$/
 
 describe( 'gulp-csv2json', () => {
 
@@ -28,10 +32,15 @@ describe( 'gulp-csv2json', () => {
         } )
 
         it( 'should return menu array, firstly', done => {
-          const json = [ { id: 0, value: '串本' } ]
           test( CSV )
             .pipe( csv2json() )
-            .pipe( assert.first( isJSON( json ) ) )
+            .pipe( assert.first( file => {
+              // match [ { id: 0a1b2c3d4f5.., value: '串本'  } ]
+              const json = JSON.parse( file.contents.toString() )
+              expect( json ).to.be.a.Array()
+              expect( json[0].id ).to.match( HASH )
+              expect( json[0].value ).to.be( '串本' )
+            } ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -65,7 +74,7 @@ describe( 'gulp-csv2json', () => {
         it( 'should be named propery', done => {
           test( CSV )
             .pipe( csv2json() )
-            .pipe( assert.second( hasName( '0.json' ) ) )
+            .pipe( assert.second( hasName( HASHED_JSON ) ) )
             .pipe( assert.end( done ) )
         } )
       } )
@@ -87,13 +96,17 @@ describe( 'gulp-csv2json', () => {
         } )
 
         it( 'should return menu array, firstly', done => {
-          const json = [
-            { id: 0, value: '串本' },
-            { id: 1, value: '白浜' }
-          ]
           test( CSV )
             .pipe( csv2json() )
-            .pipe( assert.first( isJSON( json ) ) )
+            .pipe( assert.first( file => {
+              // match [ { id: 0a1b2c.. , value: '串本' }, { id: 0a1b2c.. , value: '白浜' } ]
+              const json = JSON.parse( file.contents.toString() )
+              expect( json ).to.be.a.Array()
+              expect( json[0].id ).to.match( HASH )
+              expect( json[0].value ).to.be( '串本' )
+              expect( json[1].id ).to.match( HASH )
+              expect( json[1].value ).to.be( '白浜' )
+            } ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -121,7 +134,7 @@ describe( 'gulp-csv2json', () => {
         it( 'should be named propery', done => {
           test( CSV )
             .pipe( csv2json() )
-            .pipe( assert.second( hasName( '0.json' ) ) )
+            .pipe( assert.second( hasName( HASHED_JSON ) ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -143,7 +156,7 @@ describe( 'gulp-csv2json', () => {
         it( 'should be named propery', done => {
           test( CSV )
             .pipe( csv2json() )
-            .pipe( assert.nth( 2, hasName( '1.json' ) ) )
+            .pipe( assert.nth( 2, hasName( HASHED_JSON ) ) )
             .pipe( assert.end( done ) )
         } )
       } )
@@ -169,13 +182,17 @@ describe( 'gulp-csv2json', () => {
         } )
 
         it( 'should return menu array, firstly', done => {
-          const json = [
-            { id: 0, value: '串本' },
-            { id: 1, value: '白浜' },
-          ]
           test( CSV1, CSV2 )
             .pipe( csv2json() )
-            .pipe( assert.first( isJSON( json ) ) )
+            .pipe( assert.first( isJSON( file => {
+              // match [ { id: 0a1b2c.. , value: '串本' }, { id: 0a1b2c.. , value: '白浜' } ]
+              const json = JSON.parse( file.contents.toString() )
+              expect( json ).to.be.a.Array()
+              expect( json[0].id ).to.match( HASH )
+              expect( json[0].value ).to.be( '串本' )
+              expect( json[1].id ).to.match( HASH )
+              expect( json[1].value ).to.be( '白浜' )
+            } ) ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -202,7 +219,7 @@ describe( 'gulp-csv2json', () => {
         it( 'should be named propery', done => {
           test( CSV1, CSV2 )
             .pipe( csv2json() )
-            .pipe( assert.second( hasName( '0.json' ) ) )
+            .pipe( assert.second( hasName( HASHED_JSON ) ) )
             .pipe( assert.end( done ) )
         } )
 
@@ -224,7 +241,7 @@ describe( 'gulp-csv2json', () => {
         it( 'should be named propery', done => {
           test( CSV1, CSV2 )
             .pipe( csv2json() )
-            .pipe( assert.nth( 2, hasName( '1.json' ) ) )
+            .pipe( assert.nth( 2, hasName( HASHED_JSON ) ) )
             .pipe( assert.end( done ) )
         } )
       } )
@@ -283,8 +300,14 @@ describe( 'gulp-csv2json', () => {
         test( CSV )
           .pipe( csv2json() )
           .pipe( assert.length( 2 ) )
-          .pipe( assert.first( isJSON( [ { id:0, value: 'value1' } ] ) ) )
-          .pipe( assert.second( hasName( '0.json' ) ) )
+          .pipe( assert.first( file => {
+            // match [ { id: 0a1b2c.. , value: 'value1' } ]
+            const json = JSON.parse( file.contents.toString() )
+            expect( json ).to.be.a.Array()
+            expect( json[0].id ).to.match( HASH )
+            expect( json[0].value ).to.be( 'value1' )
+          } ) )
+          .pipe( assert.second( hasName( HASHED_JSON ) ) )
           .pipe( assert.second( isJSON( expected ) ) )
           .pipe( assert.end( done ) )
       } )
@@ -296,8 +319,8 @@ describe( 'gulp-csv2json', () => {
         test( CSV )
           .pipe( csv2json() )
           .pipe( assert.length( 2 ) )
-          .pipe( assert.first( isJSON( [ { id:0, value: 'value1' } ] ) ) )
-          .pipe( assert.second( hasName( '0.json' ) ) )
+          .pipe( assert.first( isJSON( [ { id: 0, value: 'value1' } ] ) ) )
+          .pipe( assert.second( hasName( HASHED_JSON ) ) )
           .pipe( assert.second( isJSON( expected ) ) )
           .pipe( assert.end( done ) )
       } )

--- a/tests/lib/helpers/expect-vinyl.js
+++ b/tests/lib/helpers/expect-vinyl.js
@@ -5,14 +5,24 @@
 'use strict'
 
 const expect = require( 'expect.js' )
+const path = require( 'path' )
 
 /**
  * create a callback to check if the given Vinyl has a certain filename
  * @param  {Vinyl}   file [description]
- * @param  {string}  name [description]
+ * @param  {string, regex}  name name or regex pattern
  * @return {Function}       [description]
  */
-const hasName = name => file => expect( file.path ).to.equal( `${file.base}/${name}` )
+const hasName = name => file => {
+  const basename = path.basename( file.path )
+  if ( typeof name === 'string' ) {
+    return expect( basename ).to.equal( name )
+  } else if ( name instanceof RegExp ) {
+    return expect( basename ).to.match( name )
+  } else {
+    throw new Error( 'Invalid argument type name. Provide `string` as file name or `RegExp` as file name pattern' )
+  }
+}
 
 /**
  * create a callback to check if the given Vinyl has a certain json string


### PR DESCRIPTION
#51 に対してJSONファイルの名前にハッシュをつけるよう修正しました。
- idの値をハッシュ化（ md5, ハッシュのキーは`メニュー名 + Date.now()` ）
- ビルドごとにjsonフォルダをクリーンするよう設定
- タグのロジックに上記の設定を反映