### PR TITLE
gulp clearのタイミング修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,7 +80,7 @@ gulp.task( 'clean', cb => {
   rimraf( './json', cb )
 } )
 
-gulp.task( 'data', [ 'clean' ], () => {
+gulp.task( 'data', () => {
 
   // merge streams of csv and xlsx
   streamqueue(

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.html",
   "scripts": {
     "start": "http-server -io",
-    "build": "gulp config && gulp",
+    "build": "gulp clean && gulp config && gulp",
     "test": "npm run test:unit && karma start",
     "pretest": "npm run lint && npm run build",
     "lint": "eslint --ext .js,.tag .",


### PR DESCRIPTION
npm run build実行時、その中で実行されるgulp data のclearでjsonフォルダが削除されるため、後続でconfig.jsonを参照する箇所で落ちていた。clear実行タイミングを修正しこれを回避。Win以外の環境では問題なかったがWin環境では問題があったためこれを修正。